### PR TITLE
Migrate FT_Api_Key request header to FT-Api-Key

### DIFF
--- a/app/services/userSessionApi.js
+++ b/app/services/userSessionApi.js
@@ -23,7 +23,7 @@ exports.getSessionData = function (sessionId, callback) {
 
 	var options = {
 		headers: {
-			'FT_Api_Key': env.sessionApi.key
+			'FT-Api-Key': env.sessionApi.key
 		}
 	};
 

--- a/test/app/dataHandlers/SessionDataStore/testData.js
+++ b/test/app/dataHandlers/SessionDataStore/testData.js
@@ -257,7 +257,7 @@ const requestMock = new RequestMock({
 		{
 			url: env.sessionApi.url,
 			handler: function (config) {
-				if (!config.options || config.options.headers.FT_Api_Key !== env.sessionApi.key) {
+				if (!config.options || config.options.headers['FT-Api-Key'] !== env.sessionApi.key) {
 					config.callback(null, {
 						statusCode: 401
 					});

--- a/test/app/services/userSessionApi.test.js
+++ b/test/app/services/userSessionApi.test.js
@@ -34,7 +34,7 @@ const requestMock = new RequestMock({
 		{
 			url: env.sessionApi.url,
 			handler: function (config) {
-				if (!config.options || config.options.headers.FT_Api_Key !== env.sessionApi.key) {
+				if (!config.options || config.options.headers['FT-Api-Key'] !== env.sessionApi.key) {
 					config.callback(null, {
 						statusCode: 401
 					});


### PR DESCRIPTION
FT Core are deploying breaking changes in January 2020 which will deprecate the old api key syntax.